### PR TITLE
Revert "Revert "Update to use newer signature for NewTcpRouteMapping …

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -311,7 +311,11 @@ var _ = Describe("Main", func() {
 						1234,
 						"some-ip",
 						6789,
+						6790,
+						"instance-guid",
+						nil,
 						0,
+						models.ModificationTag{},
 					),
 				}
 


### PR DESCRIPTION
…function (#19)" (#21)"

This reverts commit d0656039eb582d55402e3d5a22d848a404c41426.

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
Bring back reverted changes


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
