### PR TITLE
Replace codegangsta/cli with urfave/cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"code.cloudfoundry.org/routing-api-cli/commands"
 	"code.cloudfoundry.org/routing-api/trace"
 	uaaclient "code.cloudfoundry.org/routing-api/uaaclient"
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 const (


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
A replace directive is being used [here](https://github.com/cloudfoundry/routing-release/blob/bc125319b8be3c3b405ed932b40929ef500b9501/src/code.cloudfoundry.org/go.mod#L9) to pin `codegangsta/cli`'s version. [codegangsta/cli](https://github.com/cloudfoundry-incubator/spiff/blob/master/vendor/github.com/codegangsta/cli/README.md) has been archived, but [urfave/cli](https://github.com/urfave/cli) has the same APIs while still being maintained and `routing-release` also currently uses `negroni`, another package from `urfave` [here](https://github.com/cloudfoundry/routing-release/blob/bc125319b8be3c3b405ed932b40929ef500b9501/src/code.cloudfoundry.org/go.mod#L48)

This PR removes the replaces `codegangsta/cli` with `urfave/cli` and is a companion PR to https://github.com/cloudfoundry/routing-release/pull/423

Backward Compatibility
---------------
Breaking Change? **No**
