### PR TITLE
Re-introduce usage of newer signature for NewTcpRouteMapping function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -311,7 +311,11 @@ var _ = Describe("Main", func() {
 						1234,
 						"some-ip",
 						6789,
+						6790,
+						"instance-guid",
+						nil,
 						0,
+						models.ModificationTag{},
 					),
 				}
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

This reverts commit bb3c48941fc1f9f28a9d76f380ac802725de4fda.

Backward Compatibility
---------------
Breaking Change? no